### PR TITLE
fix: SearchVC 조회수 로드 오류 해결

### DIFF
--- a/Youfilx/API/API.swift
+++ b/Youfilx/API/API.swift
@@ -9,5 +9,6 @@ import Foundation
 
 enum API {
     static let baseUrl: String = "https://youtube.googleapis.com/youtube/v3/"
-    static let key: String = "AIzaSyDVr3OLr6gtJYUcrV9RS1NkU9i1pZ9A6S0"
+//    static let key: String = "AIzaSyDVr3OLr6gtJYUcrV9RS1NkU9i1pZ9A6S0"
+    static let key: String = "AIzaSyBxGrqgNKoSaDrQXHtm-2_ZzB2Uu1CwMJ8"
 }

--- a/Youfilx/API/YoutubeAPI.swift
+++ b/Youfilx/API/YoutubeAPI.swift
@@ -60,7 +60,7 @@ enum YoutubeAPI: TargetType {
             return [
                 "id": videoId,
                 "key": API.key,
-                "part": "snippet%2Cstatistics%2CContentDetails"
+                "part": "snippet,statistics,ContentDetails",
             ]
         case let .commentThread(videoId, nextPageToken):
             return [
@@ -84,6 +84,7 @@ enum YoutubeAPI: TargetType {
                 "id": channelId,
                 "key": API.key,
                 "part": "snippet%2Cstatistics"
+            ]
         case let .mostPopularVideos(pageToken):
             return [
                 "part": "snippet,statistics",

--- a/Youfilx/ViewController/HomeViewController.swift
+++ b/Youfilx/ViewController/HomeViewController.swift
@@ -56,6 +56,7 @@ class HomeViewController: UIViewController {
             guard let self = self else { return }
             switch response.result {
             case .success(let data):
+                print(data)
                 if let json = data as? [String: Any], let items = json["items"] as? [[String: Any]] {
                     for item in items {
                         if let id = item["id"] as? String,


### PR DESCRIPTION
- 처음 검색 시 videoId만 저장하고, 저장되면 videoInformation 로드
- videoInformation 로드 시 썸네일 이미지, 타이틀, 채널명, 조회수, 업로드 일자 가져오기